### PR TITLE
CLI & python3 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore configuration files
+*.json

--- a/python3/JSON/config.json.template
+++ b/python3/JSON/config.json.template
@@ -1,0 +1,5 @@
+{
+  "login" : "******",
+  "password" : "*******",
+  "url" : "https://aai.egi.eu/api/v1/VoMembers"
+}

--- a/python3/JSON/user.json.template
+++ b/python3/JSON/user.json.template
@@ -1,0 +1,17 @@
+{
+  "RequestType": "VoMembers",
+  "Version": "1.0",
+  "VoMembers": [
+    {
+      "Version": "1.0",
+      "VoId": "vo.access.egi.eu",
+      "Person": {
+        "Type": "CO",
+        "Id": "*******@egi.eu"
+      },
+      "Status": "Active",
+      "ValidFrom": "2020-01-01",
+      "ValidThrough": "2022-01-01"
+    }
+  ]
+}

--- a/python3/README.md
+++ b/python3/README.md
@@ -1,0 +1,91 @@
+# pysetVOrights
+
+## Requirements:
+* Members of the VO should be identified via their EGI ePUID.
+* Membership should be limited to the specified period.
+* Different membership status values should be supported, namely `Active`, `Expired`, `Deleted`.
+* Check-In should automatically change the membership status from `Active` to `Expired` beyond the validity period.
+* Python 3
+
+## Install requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+## Authentication:
+The REST client is authenticated via `login` & `password` credentials transmitted over HTTPS using the Basic Authentication scheme. More sophisticated authentication mechanisms, such as OpenID Connect, OAuth 2.0 access tokens, may be supported in the future.
+
+Configure the `JSON`/`config.json` file:
+
+```json
+{
+  "login" : "*****",
+  "password" : "******",
+  "url" : "https://aai.egi.eu/api/v1/VoMembers"
+}
+```
+
+## User configuration
+
+All these parameters are mandatory.
+
+* Specifying the user’s EGI ID,
+* The name of the VO (`vo.access.egi.eu` in the case of the EGI AoDs),
+* The status (`Active`), and
+* The valid from/through dates.
+
+Configure the `JSON`/`user.json` file settings:
+
+```json
+{
+  "RequestType": "VoMembers",
+  "Version": "1.0",
+  "VoMembers": [
+    {
+      "Version": "1.0",
+      "VoId": "vo.access.egi.eu",
+      "Person": {
+        "Type": "CO",
+        "Id": "****@egi.eu"
+      },
+      "Status": "Active",
+      "ValidFrom": "2021-01-01",
+      "ValidThrough": "2022-01-01"
+    }
+  ]
+}
+```
+
+## Usage
+
+Use the help option for the python command line interface as follows:
+
+```bash
+$ python pysetVOrights.py -h
+```
+
+* Adding a user to a VO requires:
+
+Use the `--set` option to add the user to the VO:
+
+```bash
+$ python pysetVOrights.py -s
+```
+
+* Retrieving the VO membership information for a given EGI ID:
+
+```bash
+$ python pysetVOrights.py -g
+```
+
+Beyond the `valid_through` date, the status will be automatically changed to `Expired`. So, when querying for VO membership information, it’s important to check that the status is actually set to `Active`.
+
+You can also check the VO membership information usign the APIs:
+
+```bash
+$ curl -vX GET https://aai.egi.eu.eu/api/v1/VoMembers/01234567890123456789@egi.eu \
+  -user "example-client":"veryverysecret"
+
+{"id":85,"epuid":"01234567890123456789@egi.eu","vo_id":"vo.access.egi.eu","valid_from":"2017-05-20T22:00:00.000Z","valid_through":"2017-06-21T22:00:00.000Z","status":"Active"}
+```

--- a/python3/pysetVOrights.py
+++ b/python3/pysetVOrights.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import requests
+import json
+import argparse
+from pprint import pprint
+
+def getVOMembership(login, password, url):
+    print ("\n[.] Get VO membership information for: %s"
+           % (user_data["VoMembers"][0]["Person"]["Id"]))
+    cur = requests.get(url=url, auth=(login, password))
+    membership = cur.json()
+    print ("\n[ Response ]")
+    pprint ("%s" %membership[0])
+
+def updateVOMembership(login, password, url, data):
+    print ("\n[.] Update VO membership information for a given EGI ID")
+    cur = requests.put(url=url, auth=(login, password), json=data)
+    data = cur.json()
+    print ("\n[ Response ]")
+    pprint ("%s" %data)
+
+def setVOMembership(login, password, url, data):
+    print ("\n[.] Set VO membership information for a given EGI ID")
+    headers = {'Content-Type': 'application/json'}
+    print ("[ Request ] = %s" %url)
+    pprint ("[ Payload ] = %s" %data)
+    cur = requests.post(url=url, auth=(login, password), json=data)
+    data = cur.json()
+    print ("\n[ Response ]")
+    pprint ("%s" %data)
+
+def main():
+   pass
+
+parser = argparse.ArgumentParser(
+    description="Visualize and modify user's VO membership information"
+    "Configuration file: ./JSON/config.json"
+    "User configuration file: ./JSON/user.json"
+  )
+
+group = parser.add_mutually_exclusive_group(required=True)
+
+group.add_argument(
+    "-g",
+    "--get",
+    action="store_true",
+    help="Get VO membership information for a given EGI ID",
+  )
+
+group.add_argument(
+    "-s",
+    "--set",
+    action="store_true",
+    help="Set VO membership for a given EGI ID",
+  )
+
+group.add_argument(
+    "-u",
+    "--update",
+    action="store_true",
+    help="Update VO membership for a given EGI ID",
+  )
+args = parser.parse_args()
+
+with open('./JSON/config.json') as config_file:
+    config_data = json.load(config_file)
+    login = config_data["login"]
+    password = config_data["password"]
+    url = config_data["url"]
+
+with open('./JSON/user.json') as user_file:
+    user_data = json.load(user_file)
+
+#print ("[ Request ] = %s" %url)
+#print ("[ Payload ] = %s" %user_data)
+
+if args.get:
+    url = url +  "/%s"  % (user_data["VoMembers"][0]["Person"]["Id"])
+    getVOMembership(login, password, url)
+
+if args.set:
+    setVOMembership(login, password, url, user_data)
+
+if args.update:
+    updateVOMembership(login, password, url, user_data)
+
+if __name__ == "__main__":
+    main()

--- a/python3/requirements.txt
+++ b/python3/requirements.txt
@@ -1,0 +1,4 @@
+argparse
+json
+pprint
+requests


### PR DESCRIPTION
Just an update, for using in `python3` environments, with few improvements.
It is self-contained in the `python3` folder, so we can still use the `python2` version.

`python3` required
added CLI functionalities
moved all variables in config files
`json` files are git-ignored, avoiding leak of secrets
renaming and pretty-printing.